### PR TITLE
Update outdated coming soon items

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 ## Books
 
 - [Programming with MicroPython - by Nicholas H. Tollervey, includes CircuitPython](https://www.adafruit.com/product/3706) - Discusses the MicroPython language.
-- [Coming soon: Make: Getting started with Circuit Playground Express by Mike Barela](https://www.amazon.com/Mike-Barela/e/B00OA5RJIW/ref=dp_byline_cont_book_1) - Discusses the Circuit Playground Express including programming via CircuitPython.
+- [Getting started with Circuit Playground Express by Mike Barela](https://www.amazon.com/Mike-Barela/e/B00OA5RJIW/ref=dp_byline_cont_book_1) - Discusses the Circuit Playground Express including programming via CircuitPython.
 
 ## Code
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@
 - [CircuitPython API Reference](http://circuitpython.readthedocs.io/en/latest/) - A list of functions and documentation available for CircuitPython.
 - [Circuit Playground Express CircuitPython API Reference](http://circuitpython.readthedocs.io/projects/circuitplayground/en/latest/) - The functions and documentation specific to the Circuit Playground Express using CircuitPython.
 - [CircuitPython GitHub Repository](https://github.com/adafruit/circuitpython) - The source code for CircuitPython on GitHub.
-- [CircuitPython 3.0.0 Beta 0!](https://github.com/adafruit/circuitpython/releases/tag/3.0.0-beta.0) - [And the announcement](https://blog.adafruit.com/2018/05/23/circuitpython-3-0-0-beta-0-released/)
+- [CircuitPython 3.0.3 (latest)](https://github.com/adafruit/circuitpython/releases/tag/3.0.3)
+- [CircuitPython 4.0.0 Alpha 1](https://github.com/adafruit/circuitpython/releases/tag/4.0.0-alpha.1) - [And the announcement](https://blog.adafruit.com/2018/09/21/adafruit-circuitpython-4-0-0-alpha-1-released/)
 
 ## Frameworks
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 ## Books
 
 - [Programming with MicroPython - by Nicholas H. Tollervey, includes CircuitPython](https://www.adafruit.com/product/3706) - Discusses the MicroPython language.
-- [Getting started with Circuit Playground Express by Mike Barela](https://www.amazon.com/Getting-Started-Adafruit-Circuit-Playground-dp-1680454889/dp/1680454889/ref=mt_paperback) - Discusses the Circuit Playground Express including programming via CircuitPython.
+- [Getting started with Circuit Playground Express by Mike Barela](https://www.amazon.com/Getting-Started-Adafruit-Circuit-Playground-dp-1680454889/dp/1680454889/ref=mt_paperback) (or purchase as part of your order from [the AdaFruit store](https://www.adafruit.com/product/3944)) - Discusses the Circuit Playground Express including programming via CircuitPython.
 
 ## Code
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 ## Books
 
 - [Programming with MicroPython - by Nicholas H. Tollervey, includes CircuitPython](https://www.adafruit.com/product/3706) - Discusses the MicroPython language.
-- [Getting started with Circuit Playground Express by Mike Barela](https://www.amazon.com/Mike-Barela/e/B00OA5RJIW/ref=dp_byline_cont_book_1) - Discusses the Circuit Playground Express including programming via CircuitPython.
+- [Getting started with Circuit Playground Express by Mike Barela](https://www.amazon.com/Getting-Started-Adafruit-Circuit-Playground-dp-1680454889/dp/1680454889/ref=mt_paperback) - Discusses the Circuit Playground Express including programming via CircuitPython.
 
 ## Code
 


### PR DESCRIPTION
Update the link to Mike Barela's book
* Remove "Coming Soon" from the link text
* Update link to point to the book's Amazon page
* Add link to book in the Adafruit store
Update links to CircuitPython code
* Link latest released version ([v3.0.3](https://github.com/adafruit/circuitpython/releases/tag/3.0.3))
* Add link to latest alpha ([v4.0.0-alpha1](https://github.com/adafruit/circuitpython/releases/tag/4.0.0-alpha.1))