### PR TITLE
Video embed

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@
 > A curated list of awesome CircuitPython guides, videos, libraries, frameworks, software and resources.
 
 
-<video controls src="https://user-images.githubusercontent.com/1685947/115119719-d6e21f00-9f77-11eb-84bf-3f7af59948a3.mov"></video>
-https://user-images.githubusercontent.com/1685947/115119719-d6e21f00-9f77-11eb-84bf-3f7af59948a3.mov
+<video style="display: block; width: 720px; margin: auto;" controls src="https://user-images.githubusercontent.com/1685947/115119719-d6e21f00-9f77-11eb-84bf-3f7af59948a3.mov"></video>
 
 
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 > A curated list of awesome CircuitPython guides, videos, libraries, frameworks, software and resources.
 
 
-<video style="display: block; width: 720px; margin: auto;" controls src="https://user-images.githubusercontent.com/1685947/115119719-d6e21f00-9f77-11eb-84bf-3f7af59948a3.mov"></video>
+<video style="display: block; max-width: 720px; width: 100%; margin: auto;" controls src="https://user-images.githubusercontent.com/1685947/115119719-d6e21f00-9f77-11eb-84bf-3f7af59948a3.mov"></video>
 
 
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 > A curated list of awesome CircuitPython guides, videos, libraries, frameworks, software and resources.
 
 
-
+<video controls src="https://user-images.githubusercontent.com/1685947/115119719-d6e21f00-9f77-11eb-84bf-3f7af59948a3.mov"></video>
 https://user-images.githubusercontent.com/1685947/115119719-d6e21f00-9f77-11eb-84bf-3f7af59948a3.mov
 
 


### PR DESCRIPTION
resolves: #33 

This PR resolves the issue by specifically using an embedded `<video>` tag for the video rather than relying on github markdown viewer to render the video.

I tested both on github on my branch from this PR, and on a local build of circuitpython.org/awesome page. Both are embedding the video correctly using this technique. 

This is a better and more general approach to solve the problem than my first attempt from: https://github.com/adafruit/circuitpython-org/pull/792