### PR TITLE
Add Display Example to CircuitPython_Cheatsheet.md

### DIFF
--- a/cheatsheet/CircuitPython_Cheatsheet.md
+++ b/cheatsheet/CircuitPython_Cheatsheet.md
@@ -262,3 +262,19 @@ You can use a PWM in one of two ways.
             while cpx.button_b:    # Wait for button B to be released
                 pass
             m.release(Mouse.RIGHT_BUTTON)
+            
+ ## Display ##
+
+    import board, displayio
+
+    bitmap = displayio.Bitmap(320, 240, 3)
+    bitmap[0, 0] = 0
+    palette = displayio.Palette(1)
+    palette[0] = 0xFFFFFF
+    tilegrid = displayio.TileGrid(bitmap, pixel_shader = palette)
+    group = displayio.Group()
+    group.append(tilegrid)
+    board.DISPLAY.show(group)
+
+    # Ctrl+D and any key to re-enter the REPL on-screen
+


### PR DESCRIPTION
### Tested working on Adafruit Macropad RP2040 and Raspberry Pi Zero W BareMetal Broadcom Port

## Display ##
```
    import board, displayio

    bitmap = displayio.Bitmap(320, 240, 3)
    bitmap[0, 0] = 0
    palette = displayio.Palette(1)
    palette[0] = 0xFFFFFF
    tilegrid = displayio.TileGrid(bitmap, pixel_shader = palette)
    group = displayio.Group()
    group.append(tilegrid)
    board.DISPLAY.show(group)
    
    # Ctrl+D and any key to re-enter the REPL on-screen
```

# Adafruit Macropad RP2040
![IMG_5203](https://user-images.githubusercontent.com/8195854/149641057-936036d3-c267-4ec2-a0f9-4f260d31a92f.jpg)
# Raspberry Pi Zero W BareMetal Broadcom Port
![displayio](https://user-images.githubusercontent.com/8195854/149641100-6670760d-d023-4b8e-b74a-af162d46cf90.png)


